### PR TITLE
Add case for RenderBufferBinding to getParameter

### DIFF
--- a/src/lime/_internal/backend/native/NativeOpenGLRenderContext.hx
+++ b/src/lime/_internal/backend/native/NativeOpenGLRenderContext.hx
@@ -1855,6 +1855,10 @@ class NativeOpenGLRenderContext
 			case GL.FRAMEBUFFER_BINDING:
 				var data:GLFramebuffer = getInteger(pname);
 				return data;
+			
+			case GL.RENDERBUFFER_BINDING:
+				var data:GLRenderbuffer = getInteger(pname);
+				return data;
 
 			case GL.TEXTURE_BINDING_2D, GL.TEXTURE_BINDING_CUBE_MAP:
 				var data:GLTexture = getInteger(pname);


### PR DESCRIPTION
This fixes a crash in Neko, where getParameter returned an int, which caused a crash in __getObjectID